### PR TITLE
Added Proxy Configuration for Network Settings

### DIFF
--- a/docs/resources/network_setting.md
+++ b/docs/resources/network_setting.md
@@ -39,6 +39,10 @@ Resource for managing network_setting on OpenManage Enterprise.
 - `session_setting` (Attributes) Ome Session Setting (see [below for nested schema](#nestedatt--session_setting))
 - `time_setting` (Attributes) Ome Time Setting (see [below for nested schema](#nestedatt--time_setting))
 
+### Read-Only
+
+- `id` (String) ID of the ome network setting.
+
 <a id="nestedatt--adapter_setting"></a>
 ### Nested Schema for `adapter_setting`
 

--- a/models/network_setting.go
+++ b/models/network_setting.go
@@ -217,6 +217,7 @@ type PayloadProxyConfiguration struct {
 
 // OmeNetworkSetting for network terraform attribute
 type OmeNetworkSetting struct {
+	ID                types.String       `tfsdk:"id"`
 	OmeAdapterSetting *OmeAdapterSetting `tfsdk:"adapter_setting"`
 	OmeSessionSetting *OmeSessionSetting `tfsdk:"session_setting"`
 	OmeTimeSetting    *OmeTimeSetting    `tfsdk:"time_setting"`

--- a/models/network_setting.go
+++ b/models/network_setting.go
@@ -196,7 +196,7 @@ type ProxyConfiguration struct {
 	IPAddress            string `json:"IpAddress"`
 	PortNumber           int    `json:"PortNumber"`
 	Username             string `json:"Username"`
-	Password             string    `json:"Password"`
+	Password             string `json:"Password"`
 	EnableAuthentication bool   `json:"EnableAuthentication"`
 	EnableProxy          bool   `json:"EnableProxy"`
 	SslCheckDisabled     bool   `json:"SslCheckDisabled"`
@@ -225,14 +225,14 @@ type OmeNetworkSetting struct {
 
 // OmeAdapterSetting for adapter_setting terraform attribute.
 type OmeAdapterSetting struct {
-	EnableNic      types.Bool        `tfsdk:"enable_nic"`
-	InterfaceName  types.String      `tfsdk:"interface_name"`
+	EnableNic      types.Bool         `tfsdk:"enable_nic"`
+	InterfaceName  types.String       `tfsdk:"interface_name"`
 	IPV4Config     *OmeIPv4Config     `tfsdk:"ipv4_configuration"`
 	IPV6Config     *OmeIPv6Config     `tfsdk:"ipv6_configuration"`
 	ManagementVLAN *OmeManagementVLAN `tfsdk:"management_vlan"`
 	DNSConfig      *OmeDNSConfig      `tfsdk:"dns_configuration"`
-	RebootDelay    types.Int64       `tfsdk:"reboot_delay"`
-	JobID          types.Int64       `tfsdk:"job_id"`
+	RebootDelay    types.Int64        `tfsdk:"reboot_delay"`
+	JobID          types.Int64        `tfsdk:"job_id"`
 }
 
 // OmeIPv4Config for ipv4_configuration terraform attribute

--- a/models/network_setting.go
+++ b/models/network_setting.go
@@ -196,7 +196,7 @@ type ProxyConfiguration struct {
 	IPAddress            string `json:"IpAddress"`
 	PortNumber           int    `json:"PortNumber"`
 	Username             string `json:"Username"`
-	Password             any    `json:"Password"`
+	Password             string    `json:"Password"`
 	EnableAuthentication bool   `json:"EnableAuthentication"`
 	EnableProxy          bool   `json:"EnableProxy"`
 	SslCheckDisabled     bool   `json:"SslCheckDisabled"`
@@ -217,20 +217,20 @@ type PayloadProxyConfiguration struct {
 
 // OmeNetworkSetting for network terraform attribute
 type OmeNetworkSetting struct {
-	OmeAdapterSetting OmeAdapterSetting `tfsdk:"adapter_setting"`
-	OmeSessionSetting OmeSessionSetting `tfsdk:"session_setting"`
-	OmeTimeSetting    OmeTimeSetting    `tfsdk:"time_setting"`
-	OmeProxySetting   OmeProxySetting   `tfsdk:"proxy_setting"`
+	OmeAdapterSetting *OmeAdapterSetting `tfsdk:"adapter_setting"`
+	OmeSessionSetting *OmeSessionSetting `tfsdk:"session_setting"`
+	OmeTimeSetting    *OmeTimeSetting    `tfsdk:"time_setting"`
+	OmeProxySetting   *OmeProxySetting   `tfsdk:"proxy_setting"`
 }
 
 // OmeAdapterSetting for adapter_setting terraform attribute.
 type OmeAdapterSetting struct {
 	EnableNic      types.Bool        `tfsdk:"enable_nic"`
 	InterfaceName  types.String      `tfsdk:"interface_name"`
-	IPV4Config     OmeIPv4Config     `tfsdk:"ipv4_configuration"`
-	IPV6Config     OmeIPv6Config     `tfsdk:"ipv6_configuration"`
-	ManagementVLAN OmeManagementVLAN `tfsdk:"management_vlan"`
-	DNSConfig      OmeDNSConfig      `tfsdk:"dns_configuration"`
+	IPV4Config     *OmeIPv4Config     `tfsdk:"ipv4_configuration"`
+	IPV6Config     *OmeIPv6Config     `tfsdk:"ipv6_configuration"`
+	ManagementVLAN *OmeManagementVLAN `tfsdk:"management_vlan"`
+	DNSConfig      *OmeDNSConfig      `tfsdk:"dns_configuration"`
 	RebootDelay    types.Int64       `tfsdk:"reboot_delay"`
 	JobID          types.Int64       `tfsdk:"job_id"`
 }
@@ -303,6 +303,6 @@ type OmeProxySetting struct {
 	IPAddress            types.String `tfsdk:"ip_address"`
 	ProxyPort            types.Int64  `tfsdk:"proxy_port"`
 	EnableAuthentication types.Bool   `tfsdk:"enable_authentication"`
-	Username             types.String `tfsdk:"Username"`
-	Password             types.String `tfsdk:"Password"`
+	Username             types.String `tfsdk:"username"`
+	Password             types.String `tfsdk:"password"`
 }

--- a/ome/resource_network_setting.go
+++ b/ome/resource_network_setting.go
@@ -2,10 +2,13 @@ package ome
 
 import (
 	"context"
+	"fmt"
+	"terraform-provider-ome/clients"
 	"terraform-provider-ome/models"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -59,6 +62,35 @@ func (r *networkSettingResource) Create(ctx context.Context, req resource.Create
 
 	tflog.Trace(ctx, "resource_network_setting create: updating state finished, saving ...")
 	// Save into State
+	// Create Session and defer the remove session
+	omeClient, d := r.p.createOMESession(ctx, "resource_discovery Create")
+	resp.Diagnostics.Append(d...)
+	if d.HasError() {
+		return
+	}
+	defer omeClient.RemoveSession()
+
+	// get proxy config
+	proxySettingState, err := getProxySettingState(omeClient)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"OME Proxy Create Error", err.Error(),
+		)
+	}
+	if isProxyConfigValuesChanged(plan.OmeProxySetting, proxySettingState) {
+		tflog.Trace(ctx, "change detected for proxy setting : "+fmt.Sprintf("%#v", proxySettingState)+fmt.Sprintf("%#v", plan.OmeProxySetting))
+		updateProxySettingState, err := updateProxySettingState(&plan, omeClient)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"OME Proxy Create Error", err.Error(),
+			)
+		}
+		proxySettingState = updateProxySettingState
+	} else {
+		resp.Diagnostics.AddWarning("No Change Detected.","No change in proxy setting on the infrastructure.")
+	}
+	// save proxy config into terraform state
+	state.OmeProxySetting = proxySettingState
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	tflog.Trace(ctx, "resource_network_setting create: finish")
@@ -73,7 +105,22 @@ func (r *networkSettingResource) Read(ctx context.Context, req resource.ReadRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
+	// Create Session and defer the remove session
+	omeClient, d := r.p.createOMESession(ctx, "resource_discovery Create")
+	resp.Diagnostics.Append(d...)
+	if d.HasError() {
+		return
+	}
+	defer omeClient.RemoveSession()
+	// get proxy config
+	proxySettingState, err := getProxySettingState(omeClient)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"OME Proxy Get Error", err.Error(),
+		)
+	}
+	// save proxy config into terraform state
+	state.OmeProxySetting = proxySettingState
 	tflog.Trace(ctx, "resource_network_setting read: finished reading state")
 	//Save into State
 	diags = resp.State.Set(ctx, &state)
@@ -99,8 +146,27 @@ func (r *networkSettingResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
+	// Create Session and defer the remove session
+	omeClient, d := r.p.createOMESession(ctx, "resource_discovery Create")
+	resp.Diagnostics.Append(d...)
+	if d.HasError() {
+		return
+	}
+	defer omeClient.RemoveSession()
+
+	if isProxyConfigValuesChanged(plan.OmeProxySetting, state.OmeProxySetting) {
+		updateProxySettingState, err := updateProxySettingState(&plan, omeClient)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"OME Proxy Update Error", err.Error(),
+			)
+		}
+		// save proxy config into terraform state
+		state.OmeProxySetting = updateProxySettingState
+	}
 	tflog.Trace(ctx, "resource_network_setting update: finished state update")
 	//Save into State
+
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	tflog.Trace(ctx, "resource_network_setting update: finished")
@@ -119,4 +185,51 @@ func (r *networkSettingResource) Delete(ctx context.Context, req resource.Delete
 
 	resp.State.RemoveResource(ctx)
 	tflog.Trace(ctx, "resource_network_setting delete: finished")
+}
+
+func getProxySettingState(omeClient *clients.Client) (*models.OmeProxySetting, error) {
+	proxy, err := omeClient.GetProxyConfig()
+	if err != nil {
+		return nil, err
+	}
+	proxySettingState := buildProxySettingState(&proxy)
+	return proxySettingState, err
+}
+
+func isProxyConfigValuesChanged(planProxy, stateProxy *models.OmeProxySetting) bool {
+	return (!planProxy.EnableProxy.IsUnknown() && !stateProxy.EnableProxy.Equal(planProxy.EnableProxy)) ||
+		(!planProxy.ProxyPort.IsUnknown() && planProxy.ProxyPort.ValueInt64() != stateProxy.ProxyPort.ValueInt64()) ||
+		(!planProxy.IPAddress.IsUnknown() && planProxy.IPAddress.ValueString() != stateProxy.IPAddress.ValueString()) ||
+		(!planProxy.Username.IsUnknown() && planProxy.Username.ValueString() != stateProxy.Username.ValueString()) ||
+		(!planProxy.Password.IsUnknown() && planProxy.Password.ValueString() != stateProxy.Password.ValueString()) ||
+		(!planProxy.EnableAuthentication.IsUnknown() && !stateProxy.EnableAuthentication.Equal(planProxy.EnableAuthentication))
+}
+
+func updateProxySettingState(plan *models.OmeNetworkSetting, omeClient *clients.Client) (*models.OmeProxySetting, error) {
+	payloadProxy := models.PayloadProxyConfiguration{
+		IPAddress:            plan.OmeProxySetting.IPAddress.ValueString(),
+		PortNumber:           int(plan.OmeProxySetting.ProxyPort.ValueInt64()),
+		EnableAuthentication: plan.OmeProxySetting.EnableAuthentication.ValueBool(),
+		EnableProxy:          plan.OmeProxySetting.EnableProxy.ValueBool(),
+		Username:             plan.OmeProxySetting.Username.ValueString(),
+		Password:             plan.OmeProxySetting.Password.ValueString(),
+	}
+	newProxy, err := omeClient.UpdateProxyConfig(payloadProxy)
+	proxySettingState := buildProxySettingState(&newProxy)
+	if err != nil {
+		return &models.OmeProxySetting{}, err
+	}
+	return proxySettingState, nil
+}
+
+func buildProxySettingState(proxy *models.ProxyConfiguration) *models.OmeProxySetting {
+	proxySettingState := &models.OmeProxySetting{
+		EnableProxy:          types.BoolValue(proxy.EnableProxy),
+		IPAddress:            types.StringValue(proxy.IPAddress),
+		ProxyPort:            types.Int64Value(int64(proxy.PortNumber)),
+		EnableAuthentication: types.BoolValue(proxy.EnableAuthentication),
+		Username:             types.StringValue(proxy.Username),
+		Password:             types.StringValue(proxy.Password),
+	}
+	return proxySettingState
 }

--- a/ome/resource_network_setting_schema.go
+++ b/ome/resource_network_setting_schema.go
@@ -9,6 +9,11 @@ import (
 // NetworkSettingSchema for network setting schema
 func NetworkSettingSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			MarkdownDescription: "ID of the ome network setting.",
+			Description:         "ID of the ome network setting.",
+			Computed:            true,
+		},
 
 		"adapter_setting": schema.SingleNestedAttribute{
 			MarkdownDescription: "Ome Adapter Setting",

--- a/ome/resource_network_setting_test.go
+++ b/ome/resource_network_setting_test.go
@@ -1,0 +1,152 @@
+package ome
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestNetworkSettingProxy(t *testing.T) {
+	testAccCreateNetworkProxySuccess := testProvider + `
+	resource "ome_network_setting" "code_1" {
+		proxy_setting = {
+		  enable_proxy = true
+		  ip_address = "` + DeviceIP1 + `"
+		  proxy_port = 443
+		  enable_authentication = false
+		}
+	  }
+	`
+
+	testAccUpdateNetworkProxySuccess := testProvider + `
+	resource "ome_network_setting" "code_1" {
+		proxy_setting = {
+		  enable_proxy = true
+		  ip_address = "` + DeviceIP1 + `"
+		  proxy_port = 443
+		  enable_authentication = true
+		  username = "root" 
+		  password = "root"
+		}
+	  }
+	`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCreateNetworkProxySuccess,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ome_network_setting.code_1", "proxy_setting.enable_proxy", "true"),
+				),
+			},
+			{
+				Config: testAccUpdateNetworkProxySuccess,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ome_network_setting.code_1", "proxy_setting.username", "root"),
+				),
+			},
+		},
+	})
+}
+
+func TestNetworkSettingProxyIsInfraChangeDetected(t *testing.T) {
+	testAccCreateNetworkProxy := testProvider + `
+	resource "ome_network_setting" "code_2" {
+		proxy_setting = {
+		  enable_proxy = true
+		  ip_address = "` + DeviceIP2 + `"
+		  proxy_port = 446
+		  enable_authentication = false
+		}
+	  }
+	`
+	testAccUpdateNetworkProxy := testProvider + `
+	resource "ome_network_setting" "code_2" {
+		proxy_setting = {
+		  enable_proxy = false
+		}
+	  }
+	`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCreateNetworkProxy,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ome_network_setting.code_2", "proxy_setting.enable_proxy", "true"),
+				),
+			},
+			{
+				Config: testAccUpdateNetworkProxy,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ome_network_setting.code_2", "proxy_setting.enable_proxy", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestNetworkSettingProxyInValidConfig(t *testing.T) {
+	testAccNetworkProxyInvalid := testProvider + `
+	resource "ome_network_setting" "code_1" {
+		proxy_setting = {
+			enable_proxy = false
+			ip_address = "` + DeviceIP1 + `"
+		}
+	}
+	`
+	testAccNetworkProxyInvalid1 := testProvider + `
+	resource "ome_network_setting" "code_1" {
+		proxy_setting = {
+			enable_proxy = true
+		}
+	}
+	`
+	testAccNetworkProxyInvalid2 := testProvider + `
+	resource "ome_network_setting" "code_1" {
+		proxy_setting = {
+			enable_proxy = true
+			ip_address = "` + DeviceIP1 + `"
+		  	proxy_port = 443
+		  	enable_authentication = true
+		}
+	}
+	`
+
+	testAccNetworkProxyInvalid3 := testProvider + `
+	resource "ome_network_setting" "code_1" {
+		proxy_setting = {
+			enable_proxy = true
+			ip_address = "` + DeviceIP1 + `"
+		  	proxy_port = 443
+		  	enable_authentication = false
+			username = "root"
+		}
+	}
+	`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNetworkProxyInvalid,
+				ExpectError: regexp.MustCompile(`.*please ensure enable proxy should be set to true*.`),
+			},
+			{
+				Config:      testAccNetworkProxyInvalid1,
+				ExpectError: regexp.MustCompile(`.*please ensure that you set both the IP address and port*.`),
+			},
+			{
+				Config:      testAccNetworkProxyInvalid2,
+				ExpectError: regexp.MustCompile(`.*please ensure that you set both the username and password*.`),
+			},
+			{
+				Config:      testAccNetworkProxyInvalid3,
+				ExpectError: regexp.MustCompile(`.*please ensure enable authentication should be set to true*.`),
+			},
+		},
+	})
+}

--- a/ome/resource_network_setting_test.go
+++ b/ome/resource_network_setting_test.go
@@ -150,3 +150,39 @@ func TestNetworkSettingProxyInValidConfig(t *testing.T) {
 		},
 	})
 }
+
+func TestNetworkSettingProxyNil(t *testing.T) {
+	testAccNetworkProxyCreateNil := testProvider + `
+	resource "ome_network_setting" "code_3" {
+	}
+	`
+	testAccNetworkProxyCreateUpdateNil1 := testProvider + `
+	resource "ome_network_setting" "code_4" {
+		proxy_setting = {
+			enable_proxy = false
+		}
+	}
+	`
+	testAccNetworkProxyCreateUpdateNil2 := testProvider + `
+	resource "ome_network_setting" "code_4" {
+	}
+	`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkProxyCreateNil,
+			},
+			{
+				Config: testAccNetworkProxyCreateUpdateNil1,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ome_network_setting.code_4", "proxy_setting.enable_proxy", "false"),
+				),
+			},
+			{
+				Config: testAccNetworkProxyCreateUpdateNil2,
+			},
+		},
+	})
+}


### PR DESCRIPTION
# Description
the PR adds feature to change network proxy setting

# ISSUE TYPE
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### RESOURCE OR DATASOURCE NAME
<!--- Write the short name of the resource or datasource below -->
ome_network_setting
##### OUTPUT
<!--- Paste the functionality test result below -->
```
root@lglw9915:~/ome-net/terraform-provider-ome# /root/sdk/go1.20.6/bin/go test -coverprofile=coverage.out -timeout 90m -run TestNetworkSettingProxy terraform-provider-ome/ome
ok      terraform-provider-ome/ome      11.993s coverage: 9.5% of statements
```
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
# Checklist:
![image](https://github.com/dell/terraform-provider-ome/assets/118425422/3752f861-d6e7-4f13-a0ce-f7d45aa6a02a)


- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility