### PR TITLE
Added Time Configuration For Network Setting

### DIFF
--- a/clients/client.go
+++ b/clients/client.go
@@ -340,7 +340,7 @@ func (c *Client) JSONUnMarshalSingleValue(data []byte, in interface{}) error {
 	} else if l > 1 {
 		return fmt.Errorf("multiple items found, expecting one")
 	}
-	bytes := inV[0]
+	bytes := inV[0] // #nosec G602
 	fmt.Sprintln(string(bytes))
 	if err := json.Unmarshal(bytes, in); err != nil {
 		return fmt.Errorf("error unmarshalling the item in response value: %w", err)

--- a/clients/network_setting.go
+++ b/clients/network_setting.go
@@ -76,29 +76,27 @@ func (c *Client) UpdateNetworkSessions(sessionPayload []models.SessionInfo) ([]m
 }
 
 // GetTimeConfiguration to get the time configuration of the OME.
-func (c *Client) GetTimeConfiguration() (models.TimeConfiguration, error) {
+func (c *Client) GetTimeConfiguration() (models.TimeConfig, error) {
 	response, err := c.Get(TimeConfigurationAPI, nil, nil)
 	if err != nil {
-		return models.TimeConfiguration{}, err
+		return models.TimeConfig{}, err
 	}
-
 	bodyData, _ := c.GetBodyData(response.Body)
-
-	timeConfig := models.TimeConfiguration{}
+	timeConfig := models.TimeConfig{}
 	err = c.JSONUnMarshal(bodyData, &timeConfig)
 	return timeConfig, err
 }
 
 // UpdateTimeConfiguration to update the time configuration of the OME.
-func (c *Client) UpdateTimeConfiguration(payloadTC models.TimeConfigPayload) (models.TimeConfigResponse, error) {
+func (c *Client) UpdateTimeConfiguration(payloadTC models.TimeConfig) (models.TimeConfig, error) {
 	data, _ := c.JSONMarshal(payloadTC)
 	response, err := c.Put(TimeConfigurationAPI, nil, data)
 	if err != nil {
-		return models.TimeConfigResponse{}, err
+		return models.TimeConfig{}, err
 	}
 
 	bodyData, _ := c.GetBodyData(response.Body)
-	timeConfig := models.TimeConfigResponse{}
+	timeConfig := models.TimeConfig{}
 	err = c.JSONUnMarshal(bodyData, &timeConfig)
 	return timeConfig, err
 }

--- a/clients/network_setting_test.go
+++ b/clients/network_setting_test.go
@@ -174,7 +174,7 @@ func TestNetwork_UpdateTimeConfiguration(t *testing.T) {
 
 	c, _ := NewClient(opts)
 
-	var payloadTC models.TimeConfigPayload
+	var payloadTC models.TimeConfig
 	t.Logf(string(payloadUpdateNetworkTime))
 	err := c.JSONUnMarshal(payloadUpdateNetworkTime, &payloadTC)
 	if err != nil {
@@ -182,10 +182,10 @@ func TestNetwork_UpdateTimeConfiguration(t *testing.T) {
 	}
 	tests := []struct {
 		name string
-		args models.TimeConfigPayload
+		args models.TimeConfig
 	}{
 		{"Update Network Time Successfully", payloadTC},
-		{"Update Network Time Failed", models.TimeConfigPayload{TimeZone: "invalid"}},
+		{"Update Network Time Failed", models.TimeConfig{TimeZone: "invalid"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -217,7 +217,7 @@ func TestNetwork_GetTimeZone(t *testing.T) {
 			getNetTimeZone, err := c.GetTimeZone()
 			t.Log(getNetTimeZone, err)
 			if err == nil {
-				assert.Equal(t, getNetTimeZone.Value[0].Name, "TZ_ID_38")
+				assert.Equal(t, getNetTimeZone.TimeZoneList[0].Name, "TZ_ID_38")
 			}
 		})
 	}

--- a/models/network_setting.go
+++ b/models/network_setting.go
@@ -118,28 +118,9 @@ type SessionInfo struct {
 	SessionTimeout int    `json:"SessionTimeout"`
 }
 
-// TimeConfiguration to get time configuration
-type TimeConfiguration struct {
-	OdataContext         string `json:"@odata.context"`
-	OdataType            string `json:"@odata.type"`
-	OdataID              string `json:"@odata.id"`
-	TimeZone             string `json:"TimeZone"`
-	TimeZoneIDLinux      string `json:"TimeZoneIdLinux"`
-	TimeZoneIDWindows    string `json:"TimeZoneIdWindows"`
-	EnableNTP            bool   `json:"EnableNTP"`
-	PrimaryNTPAddress    any    `json:"PrimaryNTPAddress"`
-	SecondaryNTPAddress1 any    `json:"SecondaryNTPAddress1"`
-	SecondaryNTPAddress2 any    `json:"SecondaryNTPAddress2"`
-	SystemTime           string `json:"SystemTime"`
-	TimeSource           string `json:"TimeSource"`
-	UtcTime              string `json:"UtcTime"`
-}
-
 // TimeZones to get all time zones.
 type TimeZones struct {
-	OdataContext string     `json:"@odata.context"`
-	OdataCount   int        `json:"@odata.count"`
-	Value        []TimeZone `json:"value"`
+	TimeZoneList []TimeZone `json:"value"`
 }
 
 // TimeZone for one time zone.
@@ -150,29 +131,14 @@ type TimeZone struct {
 	Name             string `json:"Name"`
 }
 
-// TimeConfigPayload to get time configuration payload.
-type TimeConfigPayload struct {
+// TimeConfig to get time configuration.
+type TimeConfig struct {
 	TimeZone             string `json:"TimeZone"`
 	EnableNTP            bool   `json:"EnableNTP"`
-	PrimaryNTPAddress    any    `json:"PrimaryNTPAddress"`
-	SecondaryNTPAddress1 any    `json:"SecondaryNTPAddress1"`
-	SecondaryNTPAddress2 any    `json:"SecondaryNTPAddress2"`
+	PrimaryNTPAddress    string `json:"PrimaryNTPAddress"`
+	SecondaryNTPAddress1 string `json:"SecondaryNTPAddress1"`
+	SecondaryNTPAddress2 string `json:"SecondaryNTPAddress2"`
 	SystemTime           string `json:"SystemTime"`
-}
-
-// TimeConfigResponse to get time config response.
-type TimeConfigResponse struct {
-	TimeZone             string `json:"TimeZone"`
-	TimeZoneIDLinux      any    `json:"TimeZoneIdLinux"`
-	TimeZoneIDWindows    any    `json:"TimeZoneIdWindows"`
-	EnableNTP            bool   `json:"EnableNTP"`
-	PrimaryNTPAddress    any    `json:"PrimaryNTPAddress"`
-	SecondaryNTPAddress1 any    `json:"SecondaryNTPAddress1"`
-	SecondaryNTPAddress2 any    `json:"SecondaryNTPAddress2"`
-	SystemTime           any    `json:"SystemTime"`
-	TimeSource           string `json:"TimeSource"`
-	UtcTime              any    `json:"UtcTime"`
-	JobID                any    `json:"JobId"`
 }
 
 // ProxyConfiguration to get proxy configuration

--- a/ome/resource_configuration_baseline.go
+++ b/ome/resource_configuration_baseline.go
@@ -35,7 +35,11 @@ import (
 
 const (
 	//NoOFTries to get the task id
-	NoOFTries = 5
+	NoOFTries           = 5
+	//NotifyNonCompliance to notify on non compliance of device
+	NotifyNonCompliance = "NOTIFY_ON_NON_COMPLIANCE" // #nosec G101
+	//NotifyOnSchedule to notify on schedule
+	NotifyOnSchedule    = "NOTIFY_ON_SCHEDULE" // #nosec G101
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -703,7 +707,7 @@ func updateBaselineState(ctx context.Context, state *models.ConfigureBaselines, 
 		dia.Append(emailerror...)
 		state.EmailAddresses = emailTfsdk
 
-		if notificationSettings.NotificationType == "NOTIFY_ON_NON_COMPLIANCE" {
+		if notificationSettings.NotificationType == NotifyNonCompliance {
 			state.NotifyOnSchedule = types.BoolValue(false)
 		} else {
 			state.NotifyOnSchedule = types.BoolValue(true)
@@ -765,9 +769,9 @@ func getPayload(ctx context.Context, plan *models.ConfigureBaselines, templateID
 			return models.ConfigurationBaselinePayload{}, fmt.Errorf(clients.ErrInvalidCronExpression)
 		}
 
-		notificationType := "NOTIFY_ON_NON_COMPLIANCE"
+		notificationType := NotifyNonCompliance
 		if plan.NotifyOnSchedule.ValueBool() {
-			notificationType = "NOTIFY_ON_SCHEDULE"
+			notificationType = NotifyOnSchedule
 		}
 
 		notificationSettings := models.NotificationSettings{

--- a/ome/resource_configuration_baseline.go
+++ b/ome/resource_configuration_baseline.go
@@ -35,11 +35,11 @@ import (
 
 const (
 	//NoOFTries to get the task id
-	NoOFTries           = 5
+	NoOFTries = 5
 	//NotifyNonCompliance to notify on non compliance of device
 	NotifyNonCompliance = "NOTIFY_ON_NON_COMPLIANCE" // #nosec G101
 	//NotifyOnSchedule to notify on schedule
-	NotifyOnSchedule    = "NOTIFY_ON_SCHEDULE" // #nosec G101
+	NotifyOnSchedule = "NOTIFY_ON_SCHEDULE" // #nosec G101
 )
 
 // Ensure the implementation satisfies the expected interfaces.


### PR DESCRIPTION
# Description
Added Time Configuration For Network Setting

# ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### RESOURCE OR DATASOURCE NAME
<!--- Write the short name of the resource or datasource below -->
```
	resource "ome_network_setting" "its_ome_time" {
		time_setting = {
		  time_zone = "TZ_ID_65"
		  enable_ntp = true 
		  primary_ntp_address = "10.x.x.1"
		  secondary_ntp_address1 = "10.x.x.2"
		  secondary_ntp_address2 = "10.x.x.3"
		}
	  }
```

##### OUTPUT
<!--- Paste the functionality test result below -->
```paste below
root@lglw9915:~/ome-net/terraform-provider-ome/test# /root/sdk/go1.20.6/bin/go test -coverprofile=coverage.out -timeout 90m -run TestNetworkSetting terraform-provider-ome/ome
ok      terraform-provider-ome/ome      72.261s coverage: 14.1% of statements
root@lglw9915:~/ome-net/terraform-provider-ome/test# go tool cover -html=coverage.out -o coverage.html
```
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
system_time attribute requires a lifecycle meta argument and trigger resource for safe system time change

resource "terraform_data" "time_trigger" {
  input = "trigger1"
}

resource "ome network setting" "its_ome _time" {
  time_setting = {
    time_zone = "TZ_ID_65"
    system_time = "2023-08-19 07:50:08.387"
  }
  lifecycle {
      ignore_changes = [time_setting-system_time]
      replace_triggered_by = [ terraform_data.time_trigger ]
  }
}
```

# Coverage Report

![image](https://github.com/dell/terraform-provider-ome/assets/118425422/8b976839-829b-460c-a423-46cedea73a05)

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility