### PR TITLE
Fix: Interchanging issuedto and issuedby data

### DIFF
--- a/models/certs.go
+++ b/models/certs.go
@@ -120,8 +120,8 @@ func NewCSRConfigModel(input CSRConfig) CSRConfigModel {
 func NewCertInfoModel(info CertInfo) CertInfoModel {
 	return CertInfoModel{
 		ID:        types.StringValue("dummy"),
-		IssuedTo:  NewCSRConfigModel(info.IssuedBy),
-		IssuedBy:  NewCSRConfigModel(info.IssuedTo),
+		IssuedTo:  NewCSRConfigModel(info.IssuedTo),
+		IssuedBy:  NewCSRConfigModel(info.IssuedBy),
 		ValidTo:   types.StringValue(info.ValidTo),
 		ValidFrom: types.StringValue(info.ValidFrom),
 	}


### PR DESCRIPTION
# Description
issuedto and issuedby data in cerificate datasource was geting interchanged. This fixes that.

# ISSUE TYPE
Bugfix Pull Request

##### RESOURCE OR DATASOURCE NAME
certificate datasource

##### OUTPUT

```
Running tool: /usr/local/go/bin/go test -timeout 5h -coverprofile=/tmp/vscode-goSsxq3D/go-code-cover -run ^TestDataSource_ReadCert$ terraform-provider-ome/ome -v

=== RUN   TestDataSource_ReadCert
--- PASS: TestDataSource_ReadCert (15.58s)
PASS
	terraform-provider-ome/ome	coverage: 5.0% of statements
ok  	terraform-provider-ome/ome	15.654s	coverage: 5.0% of statements
```

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility