### PR TITLE
Static Group Resource Fix: Add default description and add requires-replace for parent_id

### DIFF
--- a/docs/resources/static_group.md
+++ b/docs/resources/static_group.md
@@ -62,7 +62,7 @@ resource "ome_static_group" "linux-group" {
 
 - `device_ids` (Set of Number) Device ids in the group
 - `name` (String) Name of the static group resource.
-- `parent_id` (Number) ID of the parent group of the static group.
+- `parent_id` (Number) ID of the parent group of the static group. If the value of `parent_id` changes, Terraform will destroy and recreate the resource.
 
 ### Optional
 

--- a/ome/datasource_groupdevices.go
+++ b/ome/datasource_groupdevices.go
@@ -234,6 +234,7 @@ func (g *groupDevicesDatasource) Read(ctx context.Context, req datasource.ReadRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	groupDevices.ID = types.StringValue("dummy")
 	groupNames := []string{}
 	resp.Diagnostics.Append(groupDevices.DeviceGroupNames.ElementsAs(ctx, &groupNames, true)...)
 	if diags.HasError() {

--- a/ome/datasource_groupdevices_test.go
+++ b/ome/datasource_groupdevices_test.go
@@ -33,6 +33,7 @@ func TestDataSource_ReadGroupDevices(t *testing.T) {
 			{
 				Config: testgroupDeviceDS,
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ome_groupdevices_info.gd", "id"),
 					resource.TestCheckResourceAttr("data.ome_groupdevices_info.gd", "device_ids.#", "2"),
 					resource.TestCheckResourceAttr("data.ome_groupdevices_info.gd", "device_servicetags.#", "2"),
 					resource.TestCheckResourceAttr("data.ome_groupdevices_info.gd", "device_groups.%", "1"),
@@ -50,6 +51,7 @@ func TestDataSource_ReadGroupDevices(t *testing.T) {
 				// create subGroup, but it wont reflect in datasource yet
 				Config: testgroupDeviceDSWithSubGroups,
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ome_groupdevices_info.gd", "id"),
 					resource.TestCheckResourceAttr("data.ome_groupdevices_info.gd", "device_groups.test_device_group.sub_groups.#", "0"),
 				),
 			},
@@ -58,6 +60,7 @@ func TestDataSource_ReadGroupDevices(t *testing.T) {
 				// now it will reflect
 				Config: testgroupDeviceDSWithSubGroups,
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ome_groupdevices_info.gd", "id"),
 					resource.TestCheckResourceAttr("data.ome_groupdevices_info.gd", "device_groups.test_device_group.sub_groups.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(
 						"data.ome_groupdevices_info.gd",

--- a/ome/resource_static_group.go
+++ b/ome/resource_static_group.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -85,6 +86,8 @@ func (r resourceStaticGroup) Schema(_ context.Context, _ resource.SchemaRequest,
 				MarkdownDescription: "Description of the static group",
 				Description:         "Description of the static group",
 				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString(""),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -93,6 +96,9 @@ func (r resourceStaticGroup) Schema(_ context.Context, _ resource.SchemaRequest,
 				MarkdownDescription: "ID of the parent group of the static group.",
 				Description:         "ID of the parent group of the static group.",
 				Required:            true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
 			},
 			"membership_type_id": schema.Int64Attribute{
 				MarkdownDescription: "Membership type of the static group",

--- a/ome/resource_static_group.go
+++ b/ome/resource_static_group.go
@@ -93,9 +93,11 @@ func (r resourceStaticGroup) Schema(_ context.Context, _ resource.SchemaRequest,
 				},
 			},
 			"parent_id": schema.Int64Attribute{
-				MarkdownDescription: "ID of the parent group of the static group.",
-				Description:         "ID of the parent group of the static group.",
-				Required:            true,
+				MarkdownDescription: "ID of the parent group of the static group." +
+					" If the value of `parent_id` changes, Terraform will destroy and recreate the resource.",
+				Description: "ID of the parent group of the static group." +
+					" If the value of 'parent_id' changes, Terraform will destroy and recreate the resource.",
+				Required: true,
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.RequiresReplace(),
 				},


### PR DESCRIPTION
# Description

This  PR fixes the following issues.

### Issue 1 - State inconsistency when creating static group with omitted `description`

With Config
```terraform
data "ome_device" "device_by_ip" {
    filters = {     
         ip_expressions = ["abc", "def"]  
    }
}

resource "ome_static_group" "terraform-group" {
   name       = "terraform-group"
   parent_id  = 1021
   device_ids = data.ome_device.device_by_ip.devices[*].id
}
```

We get Error:
```
ome_static_group.terraform-group: Creating...
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to ome_static_group.terraform-group, provider "provider[\"registry.terraform.io/dell/ome\"]" produced an unexpected new value:
│ .description: was null, but now cty.StringVal("").
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

Solution: Make empty string as the default description.

### Issue 2 - State inconsistency while updating group `parent_id`

With Previous Config:
```terraform
resource "ome_static_group" "terraform-group" {
   name       = "terraform-group"
   parent_id  = 1021
   device_ids = ...
   decsription = "something"
}
```
and Current Config:
```terraform
resource "ome_static_group" "terraform-group" {
   name       = "terraform-group"
   parent_id  = 1032
   device_ids = ...
   decsription = "something"
}
```

We get Error:
```
ome_static_group.terraform-group: Modifying... [name=terraform-group]
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to ome_static_group.terraform-group, provider "provider[\"registry.terraform.io/dell/ome\"]" produced an unexpected new value:
│ .parent_id: was cty.NumberIntVal(1032), but now cty.NumberIntVal(1021).
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

Solution: This issue occurred because OME API silently failed to update parent id. Thus the fix is to mark the `parent_id` field as requires-replace.

# ISSUE TYPE
Bugfix Pull Request

##### RESOURCE OR DATASOURCE NAME
static group resource

##### OUTPUT
<!--- Paste the functionality test result below -->
```
root@lglap049:~/terraform-provider-ome# go test terraform-provider-ome/ome -v -run=TestStaticGroup
=== RUN   TestStaticGroup
--- PASS: TestStaticGroup (54.31s)
PASS
ok      terraform-provider-ome/ome      54.322s
root@lglap049:~/terraform-provider-ome# 
root@lglap049:~/terraform-provider-ome# 
root@lglap049:~/terraform-provider-ome# 
root@lglap049:~/terraform-provider-ome# go test terraform-provider-ome/ome -v -run=TestDataSource_ReadGroupDevices
=== RUN   TestDataSource_ReadGroupDevices
--- PASS: TestDataSource_ReadGroupDevices (21.66s)
PASS
ok      terraform-provider-ome/ome      21.677s
root@lglap049:~/terraform-provider-ome#
```

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility