### PR TITLE
Adding requires-replace to csr and cert resources

### DIFF
--- a/docs/resources/application_certificate.md
+++ b/docs/resources/application_certificate.md
@@ -57,7 +57,7 @@ resource "ome_application_certificate" "ome_cert" {
 
 ### Required
 
-- `certificate_base64` (String) Base64 encoded certificate.
+- `certificate_base64` (String) Base64 encoded certificate. Terraform will replace (delete and recreate) this resource if this attribute is modified.
 
 ### Read-Only
 

--- a/docs/resources/application_csr.md
+++ b/docs/resources/application_csr.md
@@ -67,7 +67,7 @@ resource "local_file" "csr_file" {
 
 ### Required
 
-- `specs` (Attributes) CSR specifications. (see [below for nested schema](#nestedatt--specs))
+- `specs` (Attributes) CSR specifications. Terraform will replace (delete and recreate) this resource if this attribute is modified. (see [below for nested schema](#nestedatt--specs))
 
 ### Read-Only
 


### PR DESCRIPTION
# Description
Adding requires-replace tag to csr and cert resources. This eliminates the requirement of an update function in these resources.

# ISSUE TYPE
Enhancement Pull Request

##### RESOURCE OR DATASOURCE NAME
ome_application_certificate resource
ome_application_csr            resource

##### OUTPUT

```
=== RUN   TestCert
--- PASS: TestCert (2.30s)
=== RUN   TestCertPos
--- PASS: TestCertPos (55.02s)
PASS
ok      terraform-provider-ome/ome      57.342s
```

```
=== RUN   TestCsr
--- PASS: TestCsr (8.27s)
PASS
	terraform-provider-ome/ome	coverage: 5.5% of statements
ok  	terraform-provider-ome/ome	8.355s	coverage: 5.5% of statements
```

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility