### PR TITLE
Adding validators on device datasource filters

### DIFF
--- a/ome/datasource_device_schema.go
+++ b/ome/datasource_device_schema.go
@@ -58,6 +58,9 @@ func omeDeviceDataSchema() map[string]schema.Attribute {
 					Description:         "IDs of the devices to fetch.",
 					Optional:            true,
 					ElementType:         types.Int64Type,
+					Validators: []validator.List{
+						listvalidator.SizeAtLeast(1),
+					},
 				},
 				"device_service_tags": schema.ListAttribute{
 					MarkdownDescription: "Service tags of the devices to fetch.",
@@ -66,6 +69,7 @@ func omeDeviceDataSchema() map[string]schema.Attribute {
 					ElementType:         types.StringType,
 					Validators: []validator.List{
 						listvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("ids")),
+						listvalidator.SizeAtLeast(1),
 					},
 				},
 				"ip_expressions": schema.ListAttribute{
@@ -75,12 +79,16 @@ func omeDeviceDataSchema() map[string]schema.Attribute {
 						" Supported expressions are IPv4, IPv6, CIDRs and IP ranges.",
 					Optional:    true,
 					ElementType: types.StringType,
+					Validators: []validator.List{
+						listvalidator.SizeAtLeast(1),
+					},
 				},
 				"filter_expression": schema.StringAttribute{
 					MarkdownDescription: "OData `$filter` compatible expression to be used for querying devices.",
 					Description:         "OData '$filter' compatible expression to be used for querying devices.",
 					Optional:            true,
 					Validators: []validator.String{
+						stringvalidator.LengthAtLeast(1),
 						stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("ids")),
 						stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("device_service_tags")),
 					},

--- a/ome/datasource_device_test.go
+++ b/ome/datasource_device_test.go
@@ -31,6 +31,26 @@ func TestDataSource_ReadDevice(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				Config:      testGetDevicesWithEmptyQuerys,
+				ExpectError: regexp.MustCompile(".*Attribute filters.filter_expression string length must be at least 1.*"),
+				PlanOnly:    true,
+			},
+			{
+				Config:      testGetDevicesWithNoIDs,
+				ExpectError: regexp.MustCompile(".*Attribute filters.ids list must contain at least 1 elements.*"),
+				// PlanOnly:    true,
+			},
+			{
+				Config:      testGetDevicesWithNoIPs,
+				ExpectError: regexp.MustCompile(".*Attribute filters.ip_expressions list must contain at least 1 elements.*"),
+				// PlanOnly:    true,
+			},
+			{
+				Config:      testGetDevicesWithNoSvcTags,
+				ExpectError: regexp.MustCompile(".*Attribute filters.device_service_tags list must contain at least 1 elements.*"),
+				// PlanOnly:    true,
+			},
+			{
 				Config:      testGetDevicesWithInvalidInventory,
 				ExpectError: regexp.MustCompile(".*Invalid Attribute Value Match.*"),
 				// PlanOnly:    true,
@@ -130,6 +150,37 @@ output "fetched_inventory" {
 		dev.detailed_inventory.subsytem_rollup_status != null
 		]
 	]))
+}
+`
+var testGetDevicesWithNoIDs = testProvider + `
+data "ome_device" "devs" {
+	filters = {
+		ids = []
+	}
+}
+`
+
+var testGetDevicesWithNoSvcTags = testProvider + `
+data "ome_device" "devs" {
+	filters = {
+		device_service_tags = []
+	}
+}
+`
+
+var testGetDevicesWithNoIPs = testProvider + `
+data "ome_device" "devs" {
+	filters = {
+		ip_expressions = []
+	}
+}
+`
+
+var testGetDevicesWithEmptyQuerys = testProvider + `
+data "ome_device" "devs" {
+	filters = {
+		filter_expression = ""
+	}
 }
 `
 

--- a/ome/datasource_device_test.go
+++ b/ome/datasource_device_test.go
@@ -38,22 +38,21 @@ func TestDataSource_ReadDevice(t *testing.T) {
 			{
 				Config:      testGetDevicesWithNoIDs,
 				ExpectError: regexp.MustCompile(".*Attribute filters.ids list must contain at least 1 elements.*"),
-				// PlanOnly:    true,
+				PlanOnly:    true,
 			},
 			{
 				Config:      testGetDevicesWithNoIPs,
 				ExpectError: regexp.MustCompile(".*Attribute filters.ip_expressions list must contain at least 1 elements.*"),
-				// PlanOnly:    true,
+				PlanOnly:    true,
 			},
 			{
 				Config:      testGetDevicesWithNoSvcTags,
 				ExpectError: regexp.MustCompile(".*Attribute filters.device_service_tags list must contain at least 1 elements.*"),
-				// PlanOnly:    true,
+				PlanOnly:    true,
 			},
 			{
 				Config:      testGetDevicesWithInvalidInventory,
 				ExpectError: regexp.MustCompile(".*Invalid Attribute Value Match.*"),
-				// PlanOnly:    true,
 			},
 			{
 				Config:      testGetInvalidDevices,


### PR DESCRIPTION
# Description
Adding validators on device datasource filters

# ISSUE TYPE
 Pull Request

##### RESOURCE OR DATASOURCE NAME
device datasource

##### OUTPUT
<!--- Paste the functionality test result below -->
```paste below
root@lglap049:~/terraform-provider-ome# go test terraform-provider-ome/ome -v -run=TestDataSource_ReadDevice
=== RUN   TestDataSource_ReadDevice
--- PASS: TestDataSource_ReadDevice (79.84s)
PASS
ok      terraform-provider-ome/ome      79.938s
root@lglap049:~/terraform-provider-ome#
```

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility