### PR TITLE
Adding empty string validation to device ds list filters

### DIFF
--- a/ome/datasource_device_schema.go
+++ b/ome/datasource_device_schema.go
@@ -70,6 +70,9 @@ func omeDeviceDataSchema() map[string]schema.Attribute {
 					Validators: []validator.List{
 						listvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("ids")),
 						listvalidator.SizeAtLeast(1),
+						listvalidator.ValueStringsAre(
+							stringvalidator.LengthAtLeast(1),
+						),
 					},
 				},
 				"ip_expressions": schema.ListAttribute{
@@ -81,6 +84,9 @@ func omeDeviceDataSchema() map[string]schema.Attribute {
 					ElementType: types.StringType,
 					Validators: []validator.List{
 						listvalidator.SizeAtLeast(1),
+						listvalidator.ValueStringsAre(
+							stringvalidator.LengthAtLeast(1),
+						),
 					},
 				},
 				"filter_expression": schema.StringAttribute{

--- a/ome/datasource_device_test.go
+++ b/ome/datasource_device_test.go
@@ -31,6 +31,16 @@ func TestDataSource_ReadDevice(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				Config:      testGetDevicesWithEmptyIP,
+				ExpectError: regexp.MustCompile(".*filters.ip_expressions.*string length must be at least 1.*"),
+				PlanOnly:    true,
+			},
+			{
+				Config:      testGetDevicesWithEmptySvcTag,
+				ExpectError: regexp.MustCompile(".*filters.device_service_tags.*string length must be at least 1.*"),
+				PlanOnly:    true,
+			},
+			{
 				Config:      testGetDevicesWithEmptyQuerys,
 				ExpectError: regexp.MustCompile(".*Attribute filters.filter_expression string length must be at least 1.*"),
 				PlanOnly:    true,
@@ -171,6 +181,22 @@ var testGetDevicesWithNoIPs = testProvider + `
 data "ome_device" "devs" {
 	filters = {
 		ip_expressions = []
+	}
+}
+`
+
+var testGetDevicesWithEmptySvcTag = testProvider + `
+data "ome_device" "devs" {
+	filters = {
+		device_service_tags = [""]
+	}
+}
+`
+
+var testGetDevicesWithEmptyIP = testProvider + `
+data "ome_device" "devs" {
+	filters = {
+		ip_expressions = [""]
 	}
 }
 `


### PR DESCRIPTION
# Description
Adding empty string validation to device ds list filters

# ISSUE TYPE
Bugfix Pull Request

##### RESOURCE OR DATASOURCE NAME
device datasource

##### OUTPUT
```sh
root@lglap049:~/terraform-provider-ome# go test terraform-provider-ome/ome -v -run=TestDataSource_ReadDevice
=== RUN   TestDataSource_ReadDevice
--- PASS: TestDataSource_ReadDevice (59.50s)
PASS
ok      terraform-provider-ome/ome      59.523s
root@lglap049:~/terraform-provider-ome#
```
# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility