### PR TITLE
Show Error when Invalid names Filter (Repo and Catalog)

### DIFF
--- a/docs/data-sources/firmware_catalog.md
+++ b/docs/data-sources/firmware_catalog.md
@@ -45,8 +45,8 @@ limitations under the License.
 # Get details of all the firmware catalogs 
 data "ome_firmware_catalog" "data-catalog" {
   # Can filter based on the catalog name
-  # If empty then all catalogs are returned
-  # If invalid name is set that will be ignored
+  # If at least one of the filtered names is invalid, the terraform command will return an error
+  # If you want to get all catalogs remove the names filter completely
   names = ["example_catalog_1", "example_catalog_2"]
 }
 
@@ -60,7 +60,7 @@ output "data-catalog" {
 
 ### Optional
 
-- `names` (List of String) A list of catalog names which can filter the datasource, if blank will return all catalogs.
+- `names` (Set of String) A list of catalog names which can filter the datasource
 
 ### Read-Only
 

--- a/examples/data-sources/ome_fbc_repository/provider.tf
+++ b/examples/data-sources/ome_fbc_repository/provider.tf
@@ -14,7 +14,7 @@ limitations under the License.
 terraform {
   required_providers {
     ome = {
-      source  = "registry.terraform.io/dell/ome"
+      source = "registry.terraform.io/dell/ome"
     }
   }
 }

--- a/examples/data-sources/ome_firmware_catalog/data-source.tf
+++ b/examples/data-sources/ome_firmware_catalog/data-source.tf
@@ -14,8 +14,8 @@ limitations under the License.
 # Get details of all the firmware catalogs 
 data "ome_firmware_catalog" "data-catalog" {
   # Can filter based on the catalog name
-  # If empty then all catalogs are returned
-  # If invalid name is set that will be ignored
+  # If at least one of the filtered names is invalid, the terraform command will return an error
+  # If you want to get all catalogs remove the names filter completely
   names = ["example_catalog_1", "example_catalog_2"]
 }
 

--- a/examples/data-sources/ome_firmware_catalog/provider.tf
+++ b/examples/data-sources/ome_firmware_catalog/provider.tf
@@ -14,7 +14,7 @@ limitations under the License.
 terraform {
   required_providers {
     ome = {
-      source  = "registry.terraform.io/dell/ome"
+      source = "registry.terraform.io/dell/ome"
     }
   }
 }

--- a/helper/fbc_repository_helper.go
+++ b/helper/fbc_repository_helper.go
@@ -40,7 +40,7 @@ func GetAllRepositories(client *clients.Client) ([]models.RepositoryModel, error
 }
 
 // GetFilteredRepositoriesByName get all FBC Repositories by name
-func GetFilteredRepositoriesByName(context context.Context, repos []models.RepositoryModel, plan models.OMERepositoryData) []models.RepositoryModel {
+func GetFilteredRepositoriesByName(context context.Context, repos []models.RepositoryModel, plan models.OMERepositoryData) ([]models.RepositoryModel, error) {
 	var filteredArray []models.RepositoryModel
 	var repoNames []string
 
@@ -53,5 +53,9 @@ func GetFilteredRepositoriesByName(context context.Context, repos []models.Repos
 		}
 	}
 
-	return filteredArray
+	if len(repoNames) != 0 && len(filteredArray) != len(repoNames) {
+		return nil, fmt.Errorf("one of the filtered names (%s) does not exist in the list of repositories", repoNames)
+	}
+
+	return filteredArray, nil
 }

--- a/helper/firmware_catalog_helper.go
+++ b/helper/firmware_catalog_helper.go
@@ -15,6 +15,7 @@ package helper
 
 import (
 	"context"
+	"fmt"
 	"terraform-provider-ome/clients"
 	"terraform-provider-ome/models"
 	"terraform-provider-ome/utils"
@@ -37,6 +38,10 @@ func FilterCatalogFirmware(ctx context.Context, filterElements []string, cat *mo
 			}
 			vals = append(vals, val)
 		}
+	}
+
+	if len(filterElements) != 0 && len(filterElements) != len(vals) {
+		return nil, fmt.Errorf("one of the filtered names (%s) does not exist in the list of catalogs", filterElements)
 	}
 
 	return vals, nil

--- a/models/catalog.go
+++ b/models/catalog.go
@@ -106,7 +106,7 @@ type RepositoryModel struct {
 type OMECatalogData struct {
 	ID      types.Int64           `tfsdk:"id"`
 	Catalog []OmeSigleCatalogData `tfsdk:"firmware_catalogs"`
-	Names   types.List            `tfsdk:"names"`
+	Names   []types.String        `tfsdk:"names"`
 }
 
 // OmeSigleCatalogData represents the OME Firmware Catalog

--- a/ome/datasource_firmware_baseline_compliance_repository.go
+++ b/ome/datasource_firmware_baseline_compliance_repository.go
@@ -86,13 +86,22 @@ func (g *firmwareBaselineComplianceRepositoryDatasource) Read(ctx context.Contex
 		return
 	}
 	var repos []models.RepositoryModel
+	var filterErr error
 
 	if len(plan.Names) == 0 {
 		// get all Repositories
 		repos = repositories
 	} else {
 		// get filtered Repositories
-		repos = helper.GetFilteredRepositoriesByName(ctx, repositories, plan)
+		repos, filterErr = helper.GetFilteredRepositoriesByName(ctx, repositories, plan)
+	}
+
+	if filterErr != nil {
+		resp.Diagnostics.AddError(
+			"Error Filtering Repositories",
+			filterErr.Error(),
+		)
+		return
 	}
 
 	vals := make([]models.CatalogRepository, 0)

--- a/ome/datasource_firmware_baseline_compliance_repository_test.go
+++ b/ome/datasource_firmware_baseline_compliance_repository_test.go
@@ -41,7 +41,7 @@ func TestDataSource_Fbc_Repository_Read(t *testing.T) {
 					resource.TestCheckOutput("fbc-repository", "true"),
 				),
 			},
-			// Empty Filter so should return all values
+			// Empty Filter should show error
 			{
 				Config:      filterReposEmptyFilter,
 				ExpectError: regexp.MustCompile(`.*Attribute names set must contain at least 1 elements.*`),

--- a/ome/datasource_firmware_catalog.go
+++ b/ome/datasource_firmware_catalog.go
@@ -87,10 +87,8 @@ func (g *firmwareCatalogDataSource) Read(ctx context.Context, req datasource.Rea
 		return
 	}
 	var filteredNames []string
-	diags := plan.Names.ElementsAs(ctx, &filteredNames, true)
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
-		return
+	for _, sv := range plan.Names {
+		filteredNames = append(filteredNames, sv.ValueString())
 	}
 
 	vals, filterErr := helper.FilterCatalogFirmware(ctx, filteredNames, cat)

--- a/ome/datasource_firmware_catalog_schema.go
+++ b/ome/datasource_firmware_catalog_schema.go
@@ -14,7 +14,10 @@ limitations under the License.
 package ome
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -31,11 +34,17 @@ func omeFirmwareCatalogDataSchema() map[string]schema.Attribute {
 			Computed:            true,
 			NestedObject:        schema.NestedAttributeObject{Attributes: omeSingleCatalogFirmwareDataSchema()},
 		},
-		"names": schema.ListAttribute{
-			MarkdownDescription: "A list of catalog names which can filter the datasource, if blank will return all catalogs.",
-			Description:         "A list of catalog names which can filter the datasource, if blank will return all catalogs.",
+		"names": schema.SetAttribute{
+			MarkdownDescription: "A list of catalog names which can filter the datasource",
+			Description:         "A list of catalog names which can filter the datasource",
 			Optional:            true,
 			ElementType:         types.StringType,
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthAtLeast(1),
+				),
+			},
 		},
 	}
 }

--- a/ome/datasource_firmware_catalog_test.go
+++ b/ome/datasource_firmware_catalog_test.go
@@ -43,14 +43,10 @@ func TestDataSource_FirmwareCatalogRead(t *testing.T) {
 					resource.TestCheckOutput("fetched_one", "false"),
 				),
 			},
-			// Empty Filter so should return all values
+			// Empty Filter should return error
 			{
-				Config: firmwareCatAllEmptyNameFilter + outputs,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckOutput("fetched_any", "true"),
-					resource.TestCheckOutput("fetched_many", "true"),
-					resource.TestCheckOutput("fetched_one", "false"),
-				),
+				Config:      firmwareCatAllEmptyNameFilter + outputs,
+				ExpectError: regexp.MustCompile(`.*Invalid Attribute Value*.`),
 			},
 			// Using the name filter
 			{


### PR DESCRIPTION
# Description
- When filtering Repo and Catalogs if there is an invalid Name, we should show an error. 
- When filtering on Catalogs name filter, should have at least 1 value. This change is to be consistent with the other datasources.

# ISSUE TYPE
- Bugfix Pull Request

##### RESOURCE OR DATASOURCE NAME
- Repository Datasource
- Catalog Datasource

#### Test Output
```
$ MOCKEY_CHECK_GCFLAGS=false go test -v -timeout 1h -run TestDataSource_FirmwareCatalogRead
=== RUN   TestDataSource_FirmwareCatalogRead
--- PASS: TestDataSource_FirmwareCatalogRead (16.64s)
PASS
ok      terraform-provider-ome/ome      20.656s

$ MOCKEY_CHECK_GCFLAGS=false go test -v -timeout 1h -run TestDataSource_Fbc_Repository_Read
=== RUN   TestDataSource_Fbc_Repository_Read
--- PASS: TestDataSource_Fbc_Repository_Read (17.37s)
PASS
ok      terraform-provider-ome/ome      20.010s
```
# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility