### PR TITLE
Fix Demo Comments Catalog Resource

### DIFF
--- a/docs/resources/firmware_catalog.md
+++ b/docs/resources/firmware_catalog.md
@@ -81,14 +81,14 @@ resource "ome_firmware_catalog" "firmware_catalog_example" {
     am_pm = "PM"
   }
   
-  # Domain optional value for the share (CIFS)
+  # Domain optional value for the share (CIFS), for other share types this will be ignored
   domain = "example"
 
-  # Catalog user required value for the share (CIFS), optional value for the share (HTTPS)
-  catalog_user = "example-user"
+  # Share user required value for the share (CIFS), optional value for the share (HTTPS)
+  share_user = "example-user"
 
-  # Catalog password required value for the share (CIFS), optional value for the share (HTTPS)
-  catalog_password = "example-pass"
+  # Share password required value for the share (CIFS), optional value for the share (HTTPS)
+  share_password = "example-pass"
 }
 ```
 
@@ -102,13 +102,13 @@ resource "ome_firmware_catalog" "firmware_catalog_example" {
 ### Optional
 
 - `catalog_file_path` (String) Catalog File Path. Path on the share to gather catalog data. This field is required for share_types (NFS, CIFS, HTTP, HTTPS)
-- `catalog_password` (String, Sensitive) Catalog Password. The password related to the catalog share. This field is required for share_types (CIFS, HTTPS)
 - `catalog_refresh_schedule` (Attributes) Catalog Refresh Schedule, when using automatic catalog update the schedule is required for cadence of the update. If catalog_update_type is set to manual, this field is ignored. (see [below for nested schema](#nestedatt--catalog_refresh_schedule))
 - `catalog_update_type` (String) Catalog Update Type. Sets the frequency of catalog updates. Defaults to Manual. If set to automatic, the catalog_refresh_schedule field will need to be set. Options are (Manual, Automatic).
-- `catalog_user` (String) Catalog User. The username related to the catalog share. This field is required for share_types (CIFS, HTTPS).
 - `domain` (String) Domain. The domain for the catalog. This field is optional and only used for share_types (CIFS).
 - `share_address` (String) Share Address. Gives the Ipv4, Ipv6, or FQDN of the share. This field is required for share_types (NFS, CIFS, HTTP, HTTPS)
+- `share_password` (String, Sensitive) Share Password. The password related to the share address. This field is required for share_types (CIFS, HTTPS)
 - `share_type` (String) Share Type, the type of share the catalog will pull from, Defaults to Dell. The different options will have different required fields to work properly. Options are (DELL, NFS, CIFS, HTTP, HTTPS).
+- `share_user` (String) Share User. The username related to the share address. This field is required for share_types (CIFS, HTTPS).
 
 ### Read-Only
 

--- a/examples/resources/ome_firmware_catalog/resource.tf
+++ b/examples/resources/ome_firmware_catalog/resource.tf
@@ -49,12 +49,12 @@ resource "ome_firmware_catalog" "firmware_catalog_example" {
     am_pm = "PM"
   }
   
-  # Domain optional value for the share (CIFS)
+  # Domain optional value for the share (CIFS), for other share types this will be ignored
   domain = "example"
 
-  # Catalog user required value for the share (CIFS), optional value for the share (HTTPS)
-  catalog_user = "example-user"
+  # Share user required value for the share (CIFS), optional value for the share (HTTPS)
+  share_user = "example-user"
 
-  # Catalog password required value for the share (CIFS), optional value for the share (HTTPS)
-  catalog_password = "example-pass"
+  # Share password required value for the share (CIFS), optional value for the share (HTTPS)
+  share_password = "example-pass"
 }

--- a/helper/firmware_catalog_helper.go
+++ b/helper/firmware_catalog_helper.go
@@ -79,8 +79,8 @@ func SetStateCatalogFirmware(ctx context.Context, cat models.CatalogsModel, plan
 	state.ShareType = plan.ShareType
 	state.CatalogFilePath = plan.CatalogFilePath
 	state.CatalogRefreshSchedule = plan.CatalogRefreshSchedule
-	state.CatalogUser = plan.CatalogUser
-	state.CatalogPassword = plan.CatalogPassword
+	state.ShareUser = plan.ShareUser
+	state.SharePassword = plan.SharePassword
 	state.Domain = plan.Domain
 	state.ShareAddress = plan.ShareAddress
 
@@ -165,8 +165,8 @@ func MakeCatalogJSONModel(id int64, repoID int64, plan models.OmeSingleCatalogRe
 				Description:           plan.Name.ValueString() + " terraform catalog",
 				Source:                plan.ShareAddress.ValueString(),
 				DomainName:            plan.Domain.ValueString(),
-				Username:              plan.CatalogUser.ValueString(),
-				Password:              plan.CatalogPassword.ValueString(),
+				Username:              plan.ShareUser.ValueString(),
+				Password:              plan.SharePassword.ValueString(),
 				RepositoryType:        plan.ShareType.ValueString(),
 				BackupExistingCatalog: false,
 				Editable:              true,
@@ -187,8 +187,8 @@ func MakeCatalogJSONModel(id int64, repoID int64, plan models.OmeSingleCatalogRe
 			Description:           plan.Name.ValueString() + " terraform catalog",
 			Source:                plan.ShareAddress.ValueString(),
 			DomainName:            plan.Domain.ValueString(),
-			Username:              plan.CatalogUser.ValueString(),
-			Password:              plan.CatalogPassword.ValueString(),
+			Username:              plan.ShareUser.ValueString(),
+			Password:              plan.SharePassword.ValueString(),
 			RepositoryType:        plan.ShareType.ValueString(),
 			BackupExistingCatalog: false,
 			Editable:              true,
@@ -293,9 +293,9 @@ func ValidateCatalogCreate(plan models.OmeSingleCatalogResource) error {
 	case "CIFS":
 		if plan.ShareAddress.ValueString() == "" ||
 			plan.CatalogFilePath.ValueString() == "" ||
-			plan.CatalogUser.ValueString() == "" ||
-			plan.CatalogPassword.ValueString() == "" {
-			return fmt.Errorf("invalid CIFS share configuration, please provide 'share_address', 'catalog_file_path', 'catalog_user', and 'catalog_password'")
+			plan.ShareUser.ValueString() == "" ||
+			plan.SharePassword.ValueString() == "" {
+			return fmt.Errorf("invalid CIFS share configuration, please provide 'share_address', 'catalog_file_path', 'share_user', and 'share_password'")
 		}
 	case "HTTP":
 		if plan.ShareAddress.ValueString() == "" ||

--- a/models/catalog.go
+++ b/models/catalog.go
@@ -141,8 +141,8 @@ type OmeSingleCatalogResource struct {
 	ShareAddress           types.String           `tfsdk:"share_address"`
 	CatalogFilePath        types.String           `tfsdk:"catalog_file_path"`
 	Domain                 types.String           `tfsdk:"domain"`
-	CatalogUser            types.String           `tfsdk:"catalog_user"`
-	CatalogPassword        types.String           `tfsdk:"catalog_password"`
+	ShareUser              types.String           `tfsdk:"share_user"`
+	SharePassword          types.String           `tfsdk:"share_password"`
 
 	// These are the read only resources of the catalog
 	AssociatedBaselines   types.List   `tfsdk:"associated_baselines"`

--- a/ome/resource_firmware_catalog_schema.go
+++ b/ome/resource_firmware_catalog_schema.go
@@ -162,9 +162,9 @@ func FirmwareCatalogSchema() map[string]schema.Attribute {
 				),
 			},
 		},
-		"catalog_user": schema.StringAttribute{
-			MarkdownDescription: "Catalog User. The username related to the catalog share. This field is required for share_types (CIFS, HTTPS).",
-			Description:         "Catalog User. The username related to the catalog share. This field is required for share_types (CIFS, HTTPS)",
+		"share_user": schema.StringAttribute{
+			MarkdownDescription: "Share User. The username related to the share address. This field is required for share_types (CIFS, HTTPS).",
+			Description:         "Share User. The username related to the share address. This field is required for share_types (CIFS, HTTPS)",
 			Optional:            true,
 			Validators: []validator.String{
 				stringvalidator.LengthAtLeast(1),
@@ -175,9 +175,9 @@ func FirmwareCatalogSchema() map[string]schema.Attribute {
 				),
 			},
 		},
-		"catalog_password": schema.StringAttribute{
-			MarkdownDescription: "Catalog Password. The password related to the catalog share. This field is required for share_types (CIFS, HTTPS)",
-			Description:         "Catalog Password. The password related to the catalog share. This field is required for share_types (CIFS, HTTPS)",
+		"share_password": schema.StringAttribute{
+			MarkdownDescription: "Share Password. The password related to the share address. This field is required for share_types (CIFS, HTTPS)",
+			Description:         "Share Password. The password related to the share address. This field is required for share_types (CIFS, HTTPS)",
 			Optional:            true,
 			Sensitive:           true,
 			Validators: []validator.String{

--- a/ome/resource_firmware_catalog_test.go
+++ b/ome/resource_firmware_catalog_test.go
@@ -201,8 +201,8 @@ var updateFirmwareMockError = testProvider + `
           am_pm = "PM"
         }
         domain = "example"
-        catalog_user = "example-user"
-        catalog_password = "example-pass"
+        share_user = "example-user"
+        share_password = "example-pass"
 	}
 `
 
@@ -220,8 +220,8 @@ var updateFirmwareVaildationError = testProvider + `
           am_pm = "PM"
         }
         domain = "example"
-        catalog_user = "example-user"
-        catalog_password = "example-pass"
+        share_user = "example-user"
+        share_password = "example-pass"
 	}
 `
 
@@ -278,8 +278,8 @@ var createFirmwareCatalogResource = testProvider + `
           am_pm = "PM"
         }
         domain = "example"
-        catalog_user = "example-user"
-        catalog_password = "example-pass"
+        share_user = "example-user"
+        share_password = "example-pass"
     }
 `
 
@@ -297,7 +297,7 @@ resource "ome_firmware_catalog" "cat_1" {
       am_pm = "AM"
     }
     domain = "example_update"
-    catalog_user = "example-user_update"
-    catalog_password = "example-pass_update"
+    share_user = "example-user_update"
+    share_password = "example-pass_update"
 }
 `


### PR DESCRIPTION
# Description
- Update to use name share_user and share_password.
- Give better description on domain being ignored.

# ISSUE TYPE
- Bugfix Pull Request.

##### RESOURCE OR DATASOURCE NAME
firmware_catalog resource

##### OUTPUT
```
$ go test -v -run TestFirmwareCatalogResource

Mockey check failed, please add -gcflags="all=-N -l".
(Set env MOCKEY_CHECK_GCFLAGS=false to disable gcflags check)

=== RUN   TestFirmwareCatalogResourceCreate
--- PASS: TestFirmwareCatalogResourceCreate (15.91s)
=== RUN   TestFirmwareCatalogResourceValidationCreateError
--- PASS: TestFirmwareCatalogResourceValidationCreateError (12.09s)
=== RUN   TestFirmwareCatalogResourceReadCreateUpdateErrors
--- PASS: TestFirmwareCatalogResourceReadCreateUpdateErrors (15.83s)
PASS
ok      terraform-provider-ome/ome      46.559s

```
# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility