### PR TITLE
ECS02C-1209: Remove sensitive username logging at TRACE level

### DIFF
--- a/ome/provider.go
+++ b/ome/provider.go
@@ -222,7 +222,6 @@ func (p *omeProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	resp.DataSourceData = p
 	resp.ResourceData = p
 
-	tflog.Trace(ctx, p.clientOpt.Username)
 	tflog.Trace(ctx, "Finished configuring the provider")
 }
 


### PR DESCRIPTION
## Summary
Fixed security vulnerability where OME administrator username was being logged directly via tflog.Trace, bypassing Terraform's sensitive-value masking mechanism. This username could be exposed in debug logs (TF_LOG=TRACE) during every terraform plan or apply.

## Changes
- Removed `tflog.Trace(ctx, p.clientOpt.Username)` from provider.go:225
- Kept non-sensitive confirmation log "Finished configuring the provider"

## Security
- **CWE**: CWE-532 (Insertion of Sensitive Information into Log File)
- **Severity**: High
- **Impact**: Prevents credential exposure in TRACE level logs

## Testing
- ✅ Build succeeds without errors
- ✅ All unit tests pass (73.3% coverage)
- ✅ No breaking changes
- ✅ Backward compatible

## Related
- Jira: ECS02C-1209
- Security scan: cr-full-0002